### PR TITLE
Better parsing of headers and body using RegExps

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -12,46 +12,22 @@ mailSplitter = function(data) {
 	// each line is a header, until we hit \r\r which is then followed by the message text itself through the end
 	// although we need to support folded lines http://tools.ietf.org/html/rfc2822#section-2.2.3 per https://github.com/revington
 	// and https://github.com/deitch/smtp-tester/issues/2
-	buffer = "";
-	for (i=0; i<data.length; i++) {
-		if (data[i] === "\r") {
-		  // ignore line feeds once we have carriage returns
-		  if (data[i+1] === "\n") {
-		    i++;
-		  }
-			// was the last line also a CR?
-			if (data[i+1] === "\r") {
-			  i++;
-  		  // ignore line feeds once we have carriage returns
-			  if (data[i+1] === "\n") {
-			    i++;
-			  }
-				// all the rest from here until the end is the data
-				ret.body = data.substring(i+1);
-				i = data.length;
-			} else if (data[i+1].match(/\s/)) {
-			  // handle folded headers - find the first element that is not whitespace or carriage return
-			  i++;
-			  while(data[i].match(/(\s|\r|\n)/)) {
-			    i++;
-			  }
-			  buffer += " "+data[i];
-			} else {
-				// take the previous line and save it
-				// split on :
-				/*jslint regexp:false */  
-				h = buffer.match(/^\s*([^:]+):\s*(.+)\s*$/);
-				/*jslint regexp:true */
-				ret.headers = ret.headers || {};
-				ret.headers[h[1]] = h[2];
-				buffer = "";
-			}
-		} else {
-			buffer += data[i];
-		}
-		lastChar = data[i];
-	}
-	return(ret);
+	// RegExp matches headers (including split line headers) and body
+	var split = data.match(/^(([^\r\n:]+:\s+[^\r\n]+(\r\n [^\r\n]+)*\r\n)+)\r\n([^]*)$/);
+	if (! split)
+		return ret;
+	// Body will always be last match
+	ret.body = split.slice(-1)[0];
+	// Headers will be first match
+	ret.headers = split[1].replace(/\r\n /g, ' ')
+		.replace(/\r/g, '').split('\n')
+		.reduce(function (orig, cur) { // Reduce each header into a new Object
+			cur = cur.split(':');
+			if (cur.length === 2)
+				orig[cur[0]] = cur[1].replace(/^(\s*)|(\s*)$/g, '');
+			return orig;
+		}, {});
+	return ret;
 };
 
 module.exports = {


### PR DESCRIPTION
Looping over the mail content caused issues when parsing multi-line header values (produced by nodemailer), have updated to RegExps that are more RFC2822 compliant
