### PR TITLE
Expose the smtpServer

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -19,6 +19,7 @@ module.exports = {
     smtpServer.listen(port);
 
     const smtpTester = {
+      smtpServer,
       bind(recipient, handler) {
         // Missing recipient means bind for all messages.
         if (!handler && recipient && typeof recipient === 'function')


### PR DESCRIPTION
I have some suspicion that the smtpServer fails on my app. It would be useful to expose the underlying server so that we can attach "on" event handlers to this server and inspect it.