### PR TITLE
Prepare library for NodeJS 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,12 +13,12 @@
     "fallafeljan (https://github.com/fallafeljan)"
   ],
   "engines": {
-    "node": ">=0.12"
+    "node": ">=18.0.0"
   },
   "main": "./lib/index.js",
   "dependencies": {
-    "mailparser": "^2.0.4",
-    "smtp-server": "^3.0.1"
+    "mailparser": "^3.5.0",
+    "smtp-server": "^3.11.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This will require a new major version (`2.0.0`?) since it's breaking and requires NodeJS 18.